### PR TITLE
move tag for master branch to its own script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,16 +33,7 @@ deployment:
     branch: master
     owner: jumanjihouse
     commands:
-      - docker login -e ${mail} -u ${user} -p ${pass}
-      - docker tag jumanjiman/infiniband:6 jumanjiman/infiniband:6-${TAG_BASE}
-      - docker tag jumanjiman/infiniband:7 jumanjiman/infiniband:7-${TAG_BASE}
-      - docker push jumanjiman/infiniband:6-${TAG_BASE}
-      - docker push jumanjiman/infiniband:7-${TAG_BASE}
-      - docker push jumanjiman/infiniband:6
-      - docker push jumanjiman/infiniband:7
-      - docker tag jumanjiman/infiniband:7 jumanjiman/infiniband:latest
-      - docker push jumanjiman/infiniband:latest
-      - docker logout
+      - script/publish ${TAG_BASE}
   pulls:
     branch: /^(?!master).*$/
     commands:

--- a/script/publish
+++ b/script/publish
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ex
+
+docker login -e ${mail} -u ${user} -p ${pass}
+docker tag jumanjiman/infiniband:6 jumanjiman/infiniband:6-${1}
+docker tag jumanjiman/infiniband:7 jumanjiman/infiniband:7-${1}
+docker push jumanjiman/infiniband:6-${1}
+docker push jumanjiman/infiniband:7-${1}
+docker push jumanjiman/infiniband:6
+docker push jumanjiman/infiniband:7
+docker tag jumanjiman/infiniband:7 jumanjiman/infiniband:latest
+docker push jumanjiman/infiniband:latest
+docker logout


### PR DESCRIPTION
As shown in https://circleci.com/gh/jumanjihouse/docker-infiniband/25
and https://github.com/jumanjihouse/docker-infiniband/pull/6

The content of ${TAG_BASE} gets evaluated _every_ time it's referenced
in circle.yml.

This breaks publish on master branch because it takes more than
one minute between the first tag and last push.

Therefore pass TAG_BASE as an arg to shell script to ensure
we have one and only one datetime for the image tag.
